### PR TITLE
Add missing 'id' attribute in the canvas container

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
 			<button class="btn-add-bubble">Add bubble</button>
 			<button class="btn-view-debug">View debug</button>
 			<button class="btn-toggle-background">View background</button>
-			<div></div>
+			<div id="canvas-container"></div>
 			<button class="btn-toggle-obstacles">Ignore obstacles</button>
 			<button class="btn-toggle-cohesion">Disable cohesion</button>
 			<button class="btn-toggle-alignment">Disable alignment</button>


### PR DESCRIPTION
This PR fixes a little error present in the html file. Actually the setup function tries to to create and attach a canvas to the parent element with id ''canvas-container''. As the 'id' attribute is missing in that parent element then the app crashes and no boids are drawn.